### PR TITLE
install libmunge-dev instead of libmunge2 in order to ensure the auth…

### DIFF
--- a/data/r-session-complete/bionic/r-session-complete.sdef
+++ b/data/r-session-complete/bionic/r-session-complete.sdef
@@ -11,7 +11,7 @@ From: rstudio/r-session-complete:bionic-2022.07.1-554.pro3
     # SLURM integration (mandatory)
     groupadd -g 401 slurm 
     useradd -u 401 -g 401 slurm  
-    apt-get update && apt-get install libmunge2 && rm -rf /var/cache/apt/*
+    apt-get update && apt-get install libmunge-dev && rm -rf /var/cache/apt/*
 
     # Install Java JDK (optional) 
     apt-get update -y && \


### PR DESCRIPTION
…/munge plugin in SLURM can be built