### PR TITLE
26 jupyter command not found

### DIFF
--- a/data/r-session-complete/centos7/Dockerfile
+++ b/data/r-session-complete/centos7/Dockerfile
@@ -11,6 +11,11 @@ COPY scripts/bioc.txt /
 
 RUN yum -y install yum-utils epel-release && yum-config-manager --enable powertools 
 
+# Set up of developer toolset 11 to use a more recent version of the 
+# compiler toolchain
+RUN yum -y install centos-release-scl
+RUN yum -y install devtoolset-11
+
 # Install Pro Drivers
 
 ARG PRO_DRIVERS_VERSION
@@ -76,14 +81,14 @@ RUN for PYTHON_VERSION in ${PYTHON_VERSION_LIST}; \
     do \
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        /opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl_enable devtoolset-11 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \
             rsconnect_jupyter \
             rsconnect_python \
             rsp_jupyter \
-            workbench_jupyterlab && \
+            workbench_jupyterlab" && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
@@ -111,11 +116,6 @@ RUN mkdir -p /usr/lib/rstudio-server && \
 
 # Install Java JDK (optional) 
 RUN yum -y install java-1.8.0-openjdk-devel 
-
-# Set up of gcc toolset 13 to use a more recent version of the 
-# compiler toolchain (optional)
-RUN yum -y install centos-release-scl
-RUN yum -y install devtoolset-11
 
 ARG R_VERSION_LIST
 

--- a/data/r-session-complete/centos7/Dockerfile
+++ b/data/r-session-complete/centos7/Dockerfile
@@ -81,7 +81,7 @@ RUN for PYTHON_VERSION in ${PYTHON_VERSION_LIST}; \
     do \
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        scl_enable devtoolset-11 "/opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl enable devtoolset-11 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \

--- a/data/r-session-complete/centos7/r-session-complete.sdef
+++ b/data/r-session-complete/centos7/r-session-complete.sdef
@@ -87,7 +87,7 @@ EOF
     do
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        scl_enable devtoolset-11 "/opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl enable devtoolset-11 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \

--- a/data/r-session-complete/centos7/r-session-complete.sdef
+++ b/data/r-session-complete/centos7/r-session-complete.sdef
@@ -15,6 +15,12 @@ From: centos:7
     yum -y install yum-utils epel-release
     yum-config-manager --enable powertools
 
+
+    # Set up of developer toolset 11 to use a more recent version of the 
+    # compiler toolchain
+    yum -y install centos-release-scl
+    yum -y install devtoolset-11
+
     # Install Pro Drivers
 
     yum install -y \
@@ -81,14 +87,14 @@ EOF
     do
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        /opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl_enable devtoolset-11 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \
             rsconnect_jupyter \
             rsconnect_python \
             rsp_jupyter \
-            workbench_jupyterlab && \
+            workbench_jupyterlab" && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
@@ -115,11 +121,6 @@ EOF
 
     # Install Java JDK (optional) 
     yum -y install java-1.8.0-openjdk-devel 
-
-    # Set up of developer toolset 11 to use a more recent version of the 
-    # compiler toolchain (optional)
-    yum -y install centos-release-scl
-    yum -y install devtoolset-11
 
     # Install and configure new set of defined R versions
     for R_VERSION in {{R_VERSION_LIST}}

--- a/data/r-session-complete/rockylinux8/Dockerfile
+++ b/data/r-session-complete/rockylinux8/Dockerfile
@@ -80,7 +80,7 @@ RUN for PYTHON_VERSION in ${PYTHON_VERSION_LIST}; \
     do \
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \

--- a/data/r-session-complete/rockylinux8/Dockerfile
+++ b/data/r-session-complete/rockylinux8/Dockerfile
@@ -11,6 +11,10 @@ COPY scripts/bioc.txt /
 
 RUN yum -y install yum-utils epel-release && yum-config-manager --enable powertools 
 
+# Set up of gcc toolset 13 to use a more recent version of the 
+# compiler toolchain 
+RUN yum -y install gcc-toolset-13
+
 # Install Pro Drivers
 
 ARG PRO_DRIVERS_VERSION
@@ -76,14 +80,14 @@ RUN for PYTHON_VERSION in ${PYTHON_VERSION_LIST}; \
     do \
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        /opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \
             rsconnect_jupyter \
             rsconnect_python \
             rsp_jupyter \
-            workbench_jupyterlab && \
+            workbench_jupyterlab" && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
@@ -111,10 +115,6 @@ RUN mkdir -p /usr/lib/rstudio-server && \
 
 # Install Java JDK (optional) 
 RUN yum -y install java-1.8.0-openjdk-devel 
-
-# Set up of gcc toolset 13 to use a more recent version of the 
-# compiler toolchain (optional)
-RUN yum -y install gcc-toolset-13
 
 ARG R_VERSION_LIST
 

--- a/data/r-session-complete/rockylinux8/r-session-complete.sdef
+++ b/data/r-session-complete/rockylinux8/r-session-complete.sdef
@@ -86,7 +86,7 @@ EOF
     do
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \

--- a/data/r-session-complete/rockylinux8/r-session-complete.sdef
+++ b/data/r-session-complete/rockylinux8/r-session-complete.sdef
@@ -15,6 +15,11 @@ From: rockylinux:8
     yum -y install yum-utils epel-release
     yum-config-manager --enable powertools
 
+
+    # Set up of gcc toolset 13 to use a more recent version of the 
+    # compiler toolchain 
+    yum -y install gcc-toolset-13
+
     # Install Pro Drivers
 
     yum install -y \
@@ -81,14 +86,14 @@ EOF
     do
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        /opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \
             rsconnect_jupyter \
             rsconnect_python \
             rsp_jupyter \
-            workbench_jupyterlab && \
+            workbench_jupyterlab" && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
@@ -115,10 +120,6 @@ EOF
 
     # Install Java JDK (optional) 
     yum -y install java-1.8.0-openjdk-devel 
-
-    # Set up of gcc toolset 13 to use a more recent version of the 
-    # compiler toolchain (optional)
-    yum -y install gcc-toolset-13
 
     # Install and configure new set of defined R versions
     for R_VERSION in {{ R_VERSION_LIST }}

--- a/data/r-session-complete/rockylinux9/Dockerfile
+++ b/data/r-session-complete/rockylinux9/Dockerfile
@@ -11,6 +11,12 @@ COPY scripts/bioc.txt /
 
 RUN yum -y install yum-utils epel-release && yum-config-manager --enable crb 
 
+# Set up of gcc toolset 13 to use a more recent version of the 
+# compiler toolchain
+RUN yum -y install gcc-toolset-13
+
+
+
 # Install Pro Drivers
 
 ARG PRO_DRIVERS_VERSION
@@ -76,14 +82,14 @@ RUN for PYTHON_VERSION in ${PYTHON_VERSION_LIST}; \
     do \
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        /opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \
             rsconnect_jupyter \
             rsconnect_python \
             rsp_jupyter \
-            workbench_jupyterlab && \
+            workbench_jupyterlab" && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
@@ -111,10 +117,6 @@ RUN mkdir -p /usr/lib/rstudio-server && \
 
 # Install Java JDK (optional) 
 RUN yum -y install java-1.8.0-openjdk-devel 
-
-# Set up of gcc toolset 13 to use a more recent version of the 
-# compiler toolchain (optional)
-RUN yum -y install gcc-toolset-13
 
 ARG R_VERSION_LIST
 

--- a/data/r-session-complete/rockylinux9/Dockerfile
+++ b/data/r-session-complete/rockylinux9/Dockerfile
@@ -82,7 +82,7 @@ RUN for PYTHON_VERSION in ${PYTHON_VERSION_LIST}; \
     do \
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \

--- a/data/r-session-complete/rockylinux9/r-session-complete.sdef
+++ b/data/r-session-complete/rockylinux9/r-session-complete.sdef
@@ -85,7 +85,7 @@ EOF
     do
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \

--- a/data/r-session-complete/rockylinux9/r-session-complete.sdef
+++ b/data/r-session-complete/rockylinux9/r-session-complete.sdef
@@ -15,6 +15,10 @@ From: rockylinux:9
     yum -y install yum-utils epel-release
     yum-config-manager --enable crb 
 
+    # Set up of gcc toolset 13 to use a more recent version of the 
+    # compiler toolchain 
+    yum -y install gcc-toolset-13
+
     # Install Pro Drivers
 
     yum install -y \
@@ -81,14 +85,14 @@ EOF
     do
         /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade \
             pip setuptools wheel && \
-        /opt/python/${PYTHON_VERSION}/bin/pip install \
+        scl_enable gcc-toolset-13 "/opt/python/${PYTHON_VERSION}/bin/pip install \
             ipykernel \
             jupyter \
             jupyterlab \
             rsconnect_jupyter \
             rsconnect_python \
             rsp_jupyter \
-            workbench_jupyterlab && \
+            workbench_jupyterlab" && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
         /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
@@ -115,10 +119,6 @@ EOF
 
     # Install Java JDK (optional) 
     yum -y install java-1.8.0-openjdk-devel 
-
-    # Set up of gcc toolset 13 to use a more recent version of the 
-    # compiler toolchain (optional)
-    yum -y install gcc-toolset-13
 
     # Install and configure new set of defined R versions
     for R_VERSION in {{ R_VERSION_LIST }}


### PR DESCRIPTION
The CentOS 7 build is failing to install `jupyter` as one of the dependencies it has in `Python` 3.11.6 does not exist as a wheel in the version needed (`pyzmq` 24.0.1) and fails when building from source. Wrapping the `pip install` into an `scl enable devtoolset-11` command fixes the issue. 