### PR TITLE
Allow TexLive to use user space

### DIFF
--- a/.github/actions/singularity/action.yml
+++ b/.github/actions/singularity/action.yml
@@ -11,7 +11,17 @@ inputs:
   rh_user_pass:
     description: Red Hat password for RHEL subscriptions
     required: false
-  
+  s3_bucket:
+    description: S3 bucket for caching built container images
+    required: false
+  aws_role_arn:
+    description: IAM role ARN to assume via OIDC for S3 access
+    required: false
+  aws_region:
+    description: AWS region for S3 bucket
+    required: false
+    default: eu-west-1 
+
 
 runs:
   using: composite
@@ -32,7 +42,36 @@ runs:
         docker-images: true
         swap-storage: true
 
-    - name: Build r-session-complete 
+    - name: Configure AWS credentials
+      if: ${{ inputs.s3_bucket != '' }}
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws_role_arn }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Derive container image name from build.env
+      shell: bash
+      run: |
+        source data/r-session-complete/build.env
+        echo "IMAGE_NAME=session-pwb_${PWB_VERSION}-slurm_${SLURM_VERSION}-${{ inputs.linux_distro }}.sif" >> $GITHUB_ENV
+
+    - name: Check S3 for cached image
+      if: ${{ inputs.s3_bucket != '' }}
+      env:
+        linux_distro: ${{ inputs.linux_distro }}
+      shell: bash
+      run: |
+        if aws s3 ls "s3://${{ inputs.s3_bucket }}/${IMAGE_NAME}" 2>/dev/null; then
+          echo "Cache hit — downloading ${IMAGE_NAME} from S3"
+          aws s3 cp "s3://${{ inputs.s3_bucket }}/${IMAGE_NAME}" data/r-session-complete/$linux_distro/container.sif
+          echo "CACHE_HIT=true" >> $GITHUB_ENV
+        else
+          echo "No cached image found — will build"
+          echo "CACHE_HIT=false" >> $GITHUB_ENV
+        fi
+
+    - name: Build r-session-complete
+      if: env.CACHE_HIT != 'true'
       env:
         linux_distro: ${{ inputs.linux_distro }}
         RH_USER_NAME: ${{ inputs.rh_user_name }}
@@ -45,6 +84,15 @@ runs:
           echo -e "#/bin/bash\nsubscription-manager register --username $RH_USER_NAME --password \"$RH_USER_PASS\"" > ../scripts/rhn.sh; \
         fi && \
         singularity build --force --build-arg-file ../build.env container.sif r-session-complete.sdef
+
+    - name: Upload image to S3
+      if: ${{ inputs.s3_bucket != '' && env.CACHE_HIT != 'true' }}
+      env:
+        linux_distro: ${{ inputs.linux_distro }}
+      shell: bash
+      run: |
+        echo "Uploading ${IMAGE_NAME} to S3"
+        aws s3 cp data/r-session-complete/$linux_distro/container.sif "s3://${{ inputs.s3_bucket }}/${IMAGE_NAME}"
 
     - name: Print OS Release file
       env:
@@ -160,6 +208,18 @@ runs:
       run: |
         cd data/r-session-complete/$linux_distro && \
         singularity run container.sif bash -c "source /etc/profile.d/texlive.sh && which latex"
+
+    - name: Test LaTeX user-mode package install (framed)
+      env:
+        linux_distro: ${{ inputs.linux_distro }}
+      shell: bash
+      run: |
+        cd data/r-session-complete/$linux_distro && \
+        singularity run container.sif bash -c \
+          "source /etc/profile.d/texlive.sh && \
+           tlmgr install framed && \
+           pdflatex -interaction=nonstopmode ../scripts/test-framed.tex && \
+           ls test-framed.pdf"
 
     - name: Test Session Components presence
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -26,11 +27,14 @@ jobs:
         uses: ./.github/actions/singularity
         with:
           linux_distro: "jammy"
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
 
   build-focal:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -43,11 +47,14 @@ jobs:
         uses: ./.github/actions/singularity
         with:
           linux_distro: "focal"
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
 
   build-noble:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -60,11 +67,14 @@ jobs:
         uses: ./.github/actions/singularity
         with:
           linux_distro: "noble"
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
 
   build-rockylinux8:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -77,11 +87,14 @@ jobs:
         uses: ./.github/actions/singularity
         with:
           linux_distro: "rockylinux8"
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
 
   build-rockylinux9:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -94,11 +107,14 @@ jobs:
         uses: ./.github/actions/singularity
         with:
           linux_distro: "rockylinux9"
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
 
   build-rhel9:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -113,11 +129,14 @@ jobs:
           linux_distro: "rhel9"
           rh_user_name: ${{ secrets.RH_USER_NAME }}
           rh_user_pass: ${{ secrets.RH_USER_PASS }}
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
 
   build-rhel8:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -132,3 +151,5 @@ jobs:
           linux_distro: "rhel8"
           rh_user_name: ${{ secrets.RH_USER_NAME }}
           rh_user_pass: ${{ secrets.RH_USER_PASS }}
+          s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -57,6 +57,16 @@ if [ "$(id -u)" != "0" ]; then
         [ ${#args[@]} -eq 0 ] && exit 0
         exec "$REAL_TLMGR" --usermode update "${args[@]}"
     fi
+    # After installing packages, rebuild the kpathsea filename database in the
+    # user tree so lualatex/pdflatex can find the newly installed .sty files.
+    # Without this, kpathsea's ls-R cache is stale and the install appears to
+    # succeed but TeX still reports "file not found" on the next run.
+    if [ "$1" = "install" ]; then
+        "$REAL_TLMGR" --usermode "$@"
+        STATUS=$?
+        [ $STATUS -eq 0 ] && mktexlsr "${TEXMFHOME:-$HOME/texmf}" 2>/dev/null
+        exit $STATUS
+    fi
     exec "$REAL_TLMGR" --usermode "$@"
 else
     exec "$REAL_TLMGR" "$@"

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -64,6 +64,20 @@ fi
 WRAPPER
 chmod +x /usr/local/bin/tlmgr
 
+# Wrapper for fmtutil-sys: non-root users cannot write to the system format tree.
+# Redirect to fmtutil-user, which rebuilds formats into $TEXMFVAR instead.
+# Quarto calls fmtutil-sys --all after installing packages via tlmgr.
+cat > /usr/local/bin/fmtutil-sys << 'WRAPPER'
+#!/bin/bash
+REAL_FMTUTIL=$(ls -d /usr/local/texlive/20*/bin/x86_64-linux/fmtutil-sys 2>/dev/null | head -1)
+if [ "$(id -u)" != "0" ]; then
+    exec "$(dirname $REAL_FMTUTIL)/fmtutil-user" "$@"
+else
+    exec "$REAL_FMTUTIL" "$@"
+fi
+WRAPPER
+chmod +x /usr/local/bin/fmtutil-sys
+
 # Pin tlmgr to the same mirror if one was specified
 if [ -n "${TEXLIVE_MIRROR}" ]; then
     /usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/tlmgr option repository ${TEXLIVE_MIRROR}

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
-# Install TeXlive 
+# Install TeXlive
+# Optionally set TEXLIVE_MIRROR to a CTAN mirror URL
+# (e.g. https://mirror.example.org/CTAN/systems/texlive/tlnet)
+# If unset, the default CTAN mirror redirector is used.
+
+MIRROR_OPT=${TEXLIVE_MIRROR:+--repository ${TEXLIVE_MIRROR}}
 
 curl -LO https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \
     tar xvfz install-tl-unx.tar.gz && \
     rm install-tl-unx.tar.gz && \
     cd install-tl-* && \
-    ./install-tl --scheme small --no-interaction #--repository ftp://tug.org/historic/systems/texlive/${TEXLIVE_VERSION}/tlnet-final
+    ./install-tl --scheme small --no-interaction ${MIRROR_OPT}
 
 TEXLIVE_VERSION=`ls /usr/local/texlive/ | grep [0-9]`
 
@@ -33,6 +38,11 @@ else
 fi
 WRAPPER
 chmod +x /usr/local/bin/tlmgr
+
+# Pin tlmgr to the same mirror if one was specified
+if [ -n "${TEXLIVE_MIRROR}" ]; then
+    /usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/tlmgr option repository ${TEXLIVE_MIRROR}
+fi
 
 # Install texliveonfly so it can help with auto-install missing packages
 /usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/tlmgr install texliveonfly

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -25,11 +25,15 @@ export TEXMFCONFIG=\$HOME/.texlive/texmf-config
 export TEXMFVAR=\$HOME/.texlive/texmf-var
 EOF
 
-# Install a real tlmgr wrapper script in /usr/local/bin so that non-root users
-# get --usermode automatically, including from tools like texliveonfly (Perl).
-cat > /usr/local/bin/tlmgr << 'WRAPPER'
+# Wrap tlmgr in the TeX Live bin directory itself (not just /usr/local/bin) so
+# that Quarto — which resolves tlmgr by full path relative to the TeX binary —
+# also gets the wrapper. The real binary is renamed to tlmgr-real.
+TEXLIVE_BIN=/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux
+mv ${TEXLIVE_BIN}/tlmgr ${TEXLIVE_BIN}/tlmgr-real
+
+cat > ${TEXLIVE_BIN}/tlmgr << 'WRAPPER'
 #!/bin/bash
-REAL_TLMGR=$(ls -d /usr/local/texlive/20*/bin/x86_64-linux/tlmgr 2>/dev/null | head -1)
+REAL_TLMGR="$(dirname "$0")/tlmgr-real"
 if [ "$(id -u)" != "0" ]; then
     # Explicitly set TEXMF paths so they are consistent regardless of whether
     # /etc/profile.d/texlive.sh was sourced (e.g. when called from a Quarto
@@ -79,21 +83,24 @@ else
     exec "$REAL_TLMGR" "$@"
 fi
 WRAPPER
-chmod +x /usr/local/bin/tlmgr
+chmod +x ${TEXLIVE_BIN}/tlmgr
+# Also expose via /usr/local/bin for PATH-based callers (shells, texliveonfly)
+ln -sf ${TEXLIVE_BIN}/tlmgr /usr/local/bin/tlmgr
 
-# Wrapper for fmtutil-sys: non-root users cannot write to the system format tree.
-# Redirect to fmtutil-user, which rebuilds formats into $TEXMFVAR instead.
+# Wrap fmtutil-sys in the TeX Live bin directory for the same reason.
+# Non-root users cannot write to the system format tree; redirect to fmtutil-user.
 # Quarto calls fmtutil-sys --all after installing packages via tlmgr.
-cat > /usr/local/bin/fmtutil-sys << 'WRAPPER'
+mv ${TEXLIVE_BIN}/fmtutil-sys ${TEXLIVE_BIN}/fmtutil-sys-real
+cat > ${TEXLIVE_BIN}/fmtutil-sys << 'WRAPPER'
 #!/bin/bash
-REAL_FMTUTIL=$(ls -d /usr/local/texlive/20*/bin/x86_64-linux/fmtutil-sys 2>/dev/null | head -1)
 if [ "$(id -u)" != "0" ]; then
-    exec "$(dirname $REAL_FMTUTIL)/fmtutil-user" "$@"
+    exec "$(dirname "$0")/fmtutil-user" "$@"
 else
-    exec "$REAL_FMTUTIL" "$@"
+    exec "$(dirname "$0")/fmtutil-sys-real" "$@"
 fi
 WRAPPER
-chmod +x /usr/local/bin/fmtutil-sys
+chmod +x ${TEXLIVE_BIN}/fmtutil-sys
+ln -sf ${TEXLIVE_BIN}/fmtutil-sys /usr/local/bin/fmtutil-sys
 
 # Pin tlmgr to the same mirror if one was specified
 if [ -n "${TEXLIVE_MIRROR}" ]; then

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -31,6 +31,15 @@ cat > /usr/local/bin/tlmgr << 'WRAPPER'
 #!/bin/bash
 REAL_TLMGR=$(ls -d /usr/local/texlive/20*/bin/x86_64-linux/tlmgr 2>/dev/null | head -1)
 if [ "$(id -u)" != "0" ]; then
+    # Explicitly set TEXMF paths so they are consistent regardless of whether
+    # /etc/profile.d/texlive.sh was sourced (e.g. when called from a Quarto
+    # subprocess). Without this, tlmgr --usermode falls back to version-stamped
+    # paths (~/.texlive2026/) while kpathsea looks in ~/texmf — files are
+    # installed to the wrong location and TeX still reports them as missing.
+    export TEXMFHOME="${TEXMFHOME:-$HOME/texmf}"
+    export TEXMFCONFIG="${TEXMFCONFIG:-$HOME/.texlive/texmf-config}"
+    export TEXMFVAR="${TEXMFVAR:-$HOME/.texlive/texmf-var}"
+
     # Read-only operations must NOT use --usermode: they need access to the full
     # package catalog. Without this, Quarto's "search --file foo.sty" returns
     # "no matching packages" and auto-install silently fails.
@@ -39,7 +48,7 @@ if [ "$(id -u)" != "0" ]; then
             exec "$REAL_TLMGR" "$@"
             ;;
     esac
-    [ -d "${TEXMFHOME:-$HOME/texmf}" ] || "$REAL_TLMGR" init-usertree
+    [ -d "$TEXMFHOME" ] || "$REAL_TLMGR" init-usertree
     # Skip self-update and full package updates in user mode:
     # - update --self is a no-op (users can't update the tlmgr binary)
     # - update --all is very slow and is an admin concern, not a user one
@@ -59,12 +68,10 @@ if [ "$(id -u)" != "0" ]; then
     fi
     # After installing packages, rebuild the kpathsea filename database in the
     # user tree so lualatex/pdflatex can find the newly installed .sty files.
-    # Without this, kpathsea's ls-R cache is stale and the install appears to
-    # succeed but TeX still reports "file not found" on the next run.
     if [ "$1" = "install" ]; then
         "$REAL_TLMGR" --usermode "$@"
         STATUS=$?
-        [ $STATUS -eq 0 ] && mktexlsr "${TEXMFHOME:-$HOME/texmf}" 2>/dev/null
+        [ $STATUS -eq 0 ] && mktexlsr "$TEXMFHOME" 2>/dev/null
         exit $STATUS
     fi
     exec "$REAL_TLMGR" --usermode "$@"

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -33,7 +33,7 @@ mv ${TEXLIVE_BIN}/tlmgr ${TEXLIVE_BIN}/tlmgr-real
 
 cat > ${TEXLIVE_BIN}/tlmgr << 'WRAPPER'
 #!/bin/bash
-REAL_TLMGR="$(dirname "$0")/tlmgr-real"
+REAL_TLMGR="$(dirname "$(readlink -f "$0")")/tlmgr-real"
 if [ "$(id -u)" != "0" ]; then
     # Explicitly set TEXMF paths so they are consistent regardless of whether
     # /etc/profile.d/texlive.sh was sourced (e.g. when called from a Quarto
@@ -93,10 +93,11 @@ ln -sf ${TEXLIVE_BIN}/tlmgr /usr/local/bin/tlmgr
 mv ${TEXLIVE_BIN}/fmtutil-sys ${TEXLIVE_BIN}/fmtutil-sys-real
 cat > ${TEXLIVE_BIN}/fmtutil-sys << 'WRAPPER'
 #!/bin/bash
+TEXLIVE_BIN="$(dirname "$(readlink -f "$0")")"
 if [ "$(id -u)" != "0" ]; then
-    exec "$(dirname "$0")/fmtutil-user" "$@"
+    exec "$TEXLIVE_BIN/fmtutil-user" "$@"
 else
-    exec "$(dirname "$0")/fmtutil-sys-real" "$@"
+    exec "$TEXLIVE_BIN/fmtutil-sys-real" "$@"
 fi
 WRAPPER
 chmod +x ${TEXLIVE_BIN}/fmtutil-sys

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -31,7 +31,32 @@ cat > /usr/local/bin/tlmgr << 'WRAPPER'
 #!/bin/bash
 REAL_TLMGR=$(ls -d /usr/local/texlive/20*/bin/x86_64-linux/tlmgr 2>/dev/null | head -1)
 if [ "$(id -u)" != "0" ]; then
+    # Read-only operations must NOT use --usermode: they need access to the full
+    # package catalog. Without this, Quarto's "search --file foo.sty" returns
+    # "no matching packages" and auto-install silently fails.
+    case "$1" in
+        search|info|list|check|version|print-platform*)
+            exec "$REAL_TLMGR" "$@"
+            ;;
+    esac
     [ -d "${TEXMFHOME:-$HOME/texmf}" ] || "$REAL_TLMGR" init-usertree
+    # Skip self-update and full package updates in user mode:
+    # - update --self is a no-op (users can't update the tlmgr binary)
+    # - update --all is very slow and is an admin concern, not a user one
+    # Quarto triggers both before installing missing packages; suppressing them
+    # here keeps auto-install fast.
+    if [ "$1" = "update" ]; then
+        shift
+        args=()
+        for arg in "$@"; do
+            case "$arg" in
+                --self|--all) ;;
+                *) args+=("$arg") ;;
+            esac
+        done
+        [ ${#args[@]} -eq 0 ] && exit 0
+        exec "$REAL_TLMGR" --usermode update "${args[@]}"
+    fi
     exec "$REAL_TLMGR" --usermode "$@"
 else
     exec "$REAL_TLMGR" "$@"
@@ -44,5 +69,11 @@ if [ -n "${TEXLIVE_MIRROR}" ]; then
     /usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/tlmgr option repository ${TEXLIVE_MIRROR}
 fi
 
-# Install texliveonfly so it can help with auto-install missing packages
+# Install texliveonfly so it can help with auto-install missing packages.
+# Also pre-install framed (needed by Quarto's default PDF callout boxes and
+# commonly required by knitr/rmarkdown documents).
 /usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/tlmgr install texliveonfly
+
+# Pre-generate the lualatex font database so the first user render is not slow.
+# luaotfload otherwise generates this on-demand, which can take several minutes.
+/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/luaotfload-tool --update

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -44,14 +44,17 @@ if [ "$(id -u)" != "0" ]; then
     export TEXMFCONFIG="${TEXMFCONFIG:-$HOME/.texlive/texmf-config}"
     export TEXMFVAR="${TEXMFVAR:-$HOME/.texlive/texmf-var}"
 
-    # Read-only operations must NOT use --usermode: they need access to the full
-    # package catalog. Without this, Quarto's "search --file foo.sty" returns
-    # "no matching packages" and auto-install silently fails.
+    # Read-only and detection operations must NOT use --usermode: they need
+    # access to the full package catalog and must not trigger init-usertree.
+    # --version / version: Quarto calls this to detect the TeX installation.
+    # search/info/list: Quarto calls "search --file foo.sty" to map missing
+    #   .sty files to package names; fails with "no matching packages" in usermode.
     case "$1" in
-        search|info|list|check|version|print-platform*)
+        --version|-version|version|search|info|list|check|print-platform*)
             exec "$REAL_TLMGR" "$@"
             ;;
     esac
+    # Only initialise the user tree for write operations (install/update/remove)
     [ -d "$TEXMFHOME" ] || "$REAL_TLMGR" init-usertree
     # Skip self-update and full package updates in user mode:
     # - update --self is a no-op (users can't update the tlmgr binary)

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -11,22 +11,28 @@ curl -LO https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && 
 TEXLIVE_VERSION=`ls /usr/local/texlive/ | grep [0-9]`
 
 
-# Add environment variables so that user space installa of additional texlive packages work. 
-# Also ensure that tlmgr calls for non-root users use --usermode 
+# Add environment variables so that user space installs of additional texlive packages work.
 cat > /etc/profile.d/texlive.sh << EOF
-export PATH=/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux:\$PATH
+export PATH=/usr/local/bin:/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux:\$PATH
 # User-writable TEXMF trees so tlmgr install works without root
 export TEXMFHOME=\$HOME/texmf
 export TEXMFCONFIG=\$HOME/.texlive/texmf-config
 export TEXMFVAR=\$HOME/.texlive/texmf-var
-# For non-root users, default tlmgr to user mode and init the user tree on first use
-tlmgr() {
-    if [ "\$(id -u)" != "0" ]; then
-        [ -d "\$TEXMFHOME" ] || command tlmgr init-usertree
-        command tlmgr --usermode "\$@"
-    else
-        command tlmgr "\$@"
-    fi
-}
-export -f tlmgr
 EOF
+
+# Install a real tlmgr wrapper script in /usr/local/bin so that non-root users
+# get --usermode automatically, including from tools like texliveonfly (Perl).
+cat > /usr/local/bin/tlmgr << 'WRAPPER'
+#!/bin/bash
+REAL_TLMGR=$(ls -d /usr/local/texlive/20*/bin/x86_64-linux/tlmgr 2>/dev/null | head -1)
+if [ "$(id -u)" != "0" ]; then
+    [ -d "${TEXMFHOME:-$HOME/texmf}" ] || "$REAL_TLMGR" init-usertree
+    exec "$REAL_TLMGR" --usermode "$@"
+else
+    exec "$REAL_TLMGR" "$@"
+fi
+WRAPPER
+chmod +x /usr/local/bin/tlmgr
+
+# Install texliveonfly so it can help with auto-install missing packages
+/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux/tlmgr install texliveonfly

--- a/data/r-session-complete/scripts/install-texlive.sh
+++ b/data/r-session-complete/scripts/install-texlive.sh
@@ -10,4 +10,23 @@ curl -LO https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && 
 
 TEXLIVE_VERSION=`ls /usr/local/texlive/ | grep [0-9]`
 
-echo "export PATH=/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux:\$PATH" > /etc/profile.d/texlive.sh
+
+# Add environment variables so that user space installa of additional texlive packages work. 
+# Also ensure that tlmgr calls for non-root users use --usermode 
+cat > /etc/profile.d/texlive.sh << EOF
+export PATH=/usr/local/texlive/${TEXLIVE_VERSION}/bin/x86_64-linux:\$PATH
+# User-writable TEXMF trees so tlmgr install works without root
+export TEXMFHOME=\$HOME/texmf
+export TEXMFCONFIG=\$HOME/.texlive/texmf-config
+export TEXMFVAR=\$HOME/.texlive/texmf-var
+# For non-root users, default tlmgr to user mode and init the user tree on first use
+tlmgr() {
+    if [ "\$(id -u)" != "0" ]; then
+        [ -d "\$TEXMFHOME" ] || command tlmgr init-usertree
+        command tlmgr --usermode "\$@"
+    else
+        command tlmgr "\$@"
+    fi
+}
+export -f tlmgr
+EOF

--- a/data/r-session-complete/scripts/test-framed.tex
+++ b/data/r-session-complete/scripts/test-framed.tex
@@ -1,0 +1,23 @@
+\documentclass{article}
+\usepackage{framed}
+\usepackage{xcolor}
+\definecolor{shadecolor}{rgb}{0.92, 0.92, 0.92}
+
+\begin{document}
+
+\section*{Testing \texttt{framed.sty}}
+
+A simple framed box:
+
+\begin{framed}
+  This text is inside a framed box, which requires \texttt{framed.sty}.
+  If this compiles successfully, the package was found and loaded correctly.
+\end{framed}
+
+A shaded box (also from the \texttt{framed} package):
+
+\begin{shaded}
+  This text is inside a shaded box.
+\end{shaded}
+
+\end{document}


### PR DESCRIPTION
A long-standing issue was the inability of the TexLive installation to automatically install missing packages, e.g. when run in `quarto`. This PR is fixing this now by modifying `tlmgr` and other latex CLI tool to run in user space. 